### PR TITLE
Fixed calculation of mass/mobility windows 

### DIFF
--- a/MSIGen/D.py
+++ b/MSIGen/D.py
@@ -934,7 +934,7 @@ class MSIGen_D(MSIGen_base):
             
             if i == 0:
                 # updates the metadata dictionary with instrument information
-                self.metadata = get_basic_instrument_metadata(data, self.metadata)
+                self.metadata = self.get_basic_instrument_metadata(data, self.metadata)
 
             # a list of 2d matrix, matrix: scans x (mzs +1)  , 1 -> tic
             pixels_meta = [ np.zeros((scans_per_filter_grp[i][_] , peak_counts_per_filter_grp[_] + 1)) for _ in range(num_filter_groups) ]

--- a/MSIGen/base_class.py
+++ b/MSIGen/base_class.py
@@ -797,6 +797,7 @@ class MSIGen_base(object):
         """
         Determines the upper and lower bounds for a selection window based on the provided values, tolerance.
         Defines the lower_lims and upper_lims attributes of the class.
+        Treats entries of 0, which are usually blanks in the mass list, as having a window of 0 to infinity.
 
         Args:
             val_list (list):
@@ -812,12 +813,15 @@ class MSIGen_base(object):
         if self.upper_lims is None:
             self.upper_lims = []
 
+        # Determine the upper and lower limits based on the unit of the tolerance
+        # Treat entries of 0 (which are usually blanks in the mass list) as having a window of infinity (lower limit of 0 and upper limit of infinity)
         if unit.lower() == 'ppm':
-            self.lower_lims.append(np.clip(np.array(val_list) * (1-(tol/1000000)), 0, None))
-            self.upper_lims.append(np.array(val_list) * (1+(tol/1000000)))
+            val_array = np.array(val_list)
+            self.lower_lims.append(np.where(val_array==0, 0, np.clip(val_array * (1-(tol/1000000)), 0, None)))
+            self.upper_lims.append(np.where(val_array==0, np.inf, val_array * (1+(tol/1000000))))
         else:
-            self.lower_lims.append(np.clip((np.array(val_list) - tol), 0, None))
-            self.upper_lims.append(np.array(val_list) + tol)
+            self.lower_lims.append(np.where(np.array(val_list)==0, 0, np.clip((np.array(val_list) - tol), 0, None)))
+            self.upper_lims.append(np.where(np.array(val_list)==0, np.inf, np.array(val_list) + tol))
 
     def get_all_ms_and_mobility_windows(self, mass_lists=None, tolerances=None, tolerance_units=None):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "msigen"
 
-version = "0.3.1"
+version = "0.3.2"
 
 description = "A package for converting spectrometry imaging line scan data files to a visualizable format"
 authors = ["Emerson Hernly <elhernly@gmail.com>"]


### PR DESCRIPTION
Corrected the calculation of mass and mobility windows to work as intended. Now, values in the mass list that are empty or zero result in a window from 0 to inf, resulting in effectively no mass/mobility selection. Before, it would make a window with the same tolerance centered at 0. This was especially problematic in workflows with ion mobility selection, as those would only include data from the lowest mobility window in the mass list to the highest, excluding all data outside that range.

Also fixed a minor bug in D.py.